### PR TITLE
Support for IDA 6.8 and lower

### DIFF
--- a/ext_ida/SyncPlugin.py
+++ b/ext_ida/SyncPlugin.py
@@ -43,6 +43,7 @@ except:
 import idaapi
 import idautils
 from idaapi import PluginForm
+import idc
 
 
 if sys.platform == 'win32':
@@ -982,7 +983,7 @@ class SyncForm_t(PluginForm):
         print "[*] init broker,", cmdline
 
         self.broker = Broker(self.parser)
-        env = QProcessEnvironment.systemEnvironment()
+        env = QtCore.QProcessEnvironment.systemEnvironment()
         env.insert("IDB_PATH", IDB_PATH)
         env.insert("PYTHON_PATH", os.path.realpath(PYTHON_PATH))
         env.insert("PYTHON_BIN", PYTHON_BIN)
@@ -1050,15 +1051,16 @@ class SyncForm_t(PluginForm):
     def OnCreate(self, form):
         print "[sync] form create"
 
+        self.hotkeys_ctx = []
+        self.broker = None
+
         # Get parent widget
-        # parent = self.FormToPyQtWidget(form)
         parent = sark.qt.form_to_widget(form)
 
         # Create checkbox
         self.cb = QtWidgets.QCheckBox("Synchronization enable")
         self.cb.move(20, 20)
-        sark.qt.connect_method_to_signal(self.cb, "StateChanged(int)", self.cb_change_state)
-        # self.cb.stateChanged.connect(self.cb_change_state)
+        sark.qt.connect_method_to_signal(self.cb, "stateChanged(int)", self.cb_change_state)
 
         # Create label
         label = QtWidgets.QLabel('Overwrite idb name:')
@@ -1082,7 +1084,7 @@ class SyncForm_t(PluginForm):
         # Create restart button
         self.btn = QtWidgets.QPushButton('restart', parent)
         self.btn.setToolTip('Restart broker.')
-        self.btn.clicked.connect(self.cb_btn_restart)
+        sark.qt.connect_method_to_signal(self.btn, 'clicked()', self.cb_btn_restart)
 
         # Create layout
         layout = QtWidgets.QGridLayout()

--- a/ext_ida/SyncPlugin.py
+++ b/ext_ida/SyncPlugin.py
@@ -32,6 +32,7 @@ import base64
 import ctypes
 import socket
 import ConfigParser
+import sark.qt
 
 try:
     import argparse
@@ -66,8 +67,7 @@ if not site_packages in sys.path:
     sys.path.insert(0, site_packages)
 
 try:
-    from PyQt5 import QtCore, QtWidgets
-    from PyQt5.QtCore import QProcess, QProcessEnvironment
+    from sark.qt import QtCore, QtWidgets
 except:
     print "[-] failed to import Qt libs from PyQt5\n%s" % repr(sys.exc_info())
     sys.exit(0)
@@ -1051,12 +1051,14 @@ class SyncForm_t(PluginForm):
         print "[sync] form create"
 
         # Get parent widget
-        parent = self.FormToPyQtWidget(form)
+        # parent = self.FormToPyQtWidget(form)
+        parent = sark.qt.form_to_widget(form)
 
         # Create checkbox
         self.cb = QtWidgets.QCheckBox("Synchronization enable")
         self.cb.move(20, 20)
-        self.cb.stateChanged.connect(self.cb_change_state)
+        sark.qt.connect_method_to_signal(self.cb, "StateChanged(int)", self.cb_change_state)
+        # self.cb.stateChanged.connect(self.cb_change_state)
 
         # Create label
         label = QtWidgets.QLabel('Overwrite idb name:')


### PR DESCRIPTION
closes #1 

This patch is using the Qt utilities in Sark to allow the same code to work in both IDA6.9/Qt5 and IDA6.8/Qt4 and older.