### PR TITLE
new gdb cmds, better sync and support external pid/mappings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -504,7 +504,7 @@ In some scenario such as debugging embedded devices over serial, gdb is not awar
 `/proc/<pid>/maps`. In this case, we import a different script than sync.py in gdb. This script is quite simple and imports sync.py. The only difference is we create a context that is passed to `Sync()` when instanciating the object.
 It allows overriding some fields such as the pid or mappings but others could be added if required.
 
-  custom_sync.py:::
+custom_sync.py::
 
     from sync import *
 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ ret-sync
 From debuggers and dynamic analysis we got:
 
 * local view, with live dynamic context (registers, memory, etc.)
-* built-in specialized features/API (ex: Windbg's !peb, !drvobj, !address, etc.)
+* built-in specialized features/API (ex: WinDbg's !peb, !drvobj, !address, etc.)
 
 
 From IDA and static analysis we got:
@@ -29,6 +29,8 @@ Keys features:
 ret-sync is a fork of `qb-sync <https://github.com/quarkslab/qb-sync>`_ that I developed and maintained during my stay at `Quarkslab <http://www.quarkslab.com>`_.
 
 
+Below we detail most of the commands for IDA/Windbg but most concepts apply to all debuggers so
+please read the WinDbg section first even if you want to work with other debugggers.
 
 
 Content
@@ -74,8 +76,12 @@ included in Python standard libraries for release >= 2.7.
 
 
 
+WinDbg
+------
+
+
 Build it
---------
+++++++++
 
 Use the Visual Studio 2013 solution provided in ``ext_windbg``,
 (see http://www.visualstudio.com/en-us/news/vs2013-community-vs.aspx if needed).
@@ -83,14 +89,14 @@ Use the Visual Studio 2013 solution provided in ``ext_windbg``,
 
 
 Use it
-------
+++++++
 
 0. If necessary, set:
 
    * ``PYTHON_PATH`` in ``SyncPlugin.py``
    * ``BROKER_PATH`` in ``SyncPlugin.py``, by default look for ``broker.py`` in current plugin path
    * ``HOST`` in ``broker.py``, localhost is the default interface.
-     
+
    ``broker.py`` and ``sync.dll`` check for a configuration file named ``.sync`` in user's home directory.
    (IDA's side broker.py and dispatcher.py actually look for the configuration file in the IDB's
    directory first).
@@ -134,8 +140,8 @@ Use it
     0:000> .load sync
     [sync.dll] DebugExtensionInitialize, ExtensionApis loaded
 
-	
-5. Sync Windbg::
+
+5. Sync WinDbg::
 
     0:000> !sync
     [sync] No argument found, using default host (127.0.0.1:9100)
@@ -143,7 +149,7 @@ Use it
     [sync] probing sync
     [sync] sync is now enabled with host 192.168.208.1
 
-	
+
    In IDA's Output window::
 
     [*] << broker << dispatcher msg: new debugger client: dbg connect - HostMachine\HostUser
@@ -152,7 +158,7 @@ Use it
 
     [sync] idb is enabled with the idb client matching the module name.
 
-	
+
 6. IDA plugin's GUI
 
    ``Overwrite idb name`` input field is meant to change the default idb name. It is
@@ -161,12 +167,12 @@ Use it
    (like a ``foo.exe`` and ``foo.dll``), this can be used to ease matching.
    Please note, if you modify the input field while the sync is active, you have to re-register
    with the dispatcher; this can be done simply by using the "``Restart``" button.
-   
+
    Please note that it is possible to alias by default using the ``.sync config`` file::
-   
+
        [<ida_root_filename>]
        name=<alias name>
-   
+
    The section name is the idb's root file name and has only one option: "``name``".
 
 
@@ -175,7 +181,7 @@ Use it
 
 
 Extra commands
----------------
+++++++++++++++
 
 * **!syncoff**
 
@@ -211,7 +217,7 @@ Extra commands
 
 
 * **!rcmt [-a address]**
- 
+
   Reset comment at current ip in IDA:::
 
     [WinDbg]
@@ -239,7 +245,7 @@ Extra commands
   Note: calling this command without argument reset the function's comment.
 
 * **!raddr <expression>**
- 
+
   Add a comment with rebased address evaluated from expression
 
 * **!rln <expression>**
@@ -286,7 +292,7 @@ Extra commands
 
 
 * **!idblist**
- 
+
   Get list of all IDB clients connected to the dispatcher:::
 
     [WinDbg]
@@ -295,7 +301,7 @@ Extra commands
         [0] target.exe
 
 * **!syncmodauto <on|off>**
- 
+
   Enable/disable idb auto switch based on module name:::
 
     [WinDbg]
@@ -315,12 +321,12 @@ Extra commands
     > current idb set to 0
 
   In this example, current active idb client would have been set to::
- 
+
 	[0] target.exe.
 
 
 * **!jmpto <expression>**
- 
+
   Expression given as argument is evaluated in the context of the current debugger's status.
   IDA's view is then synced with the resulting address if a matching module is registered.
   Can be seen as a manual synching, relocation is automatically performed, on the fly.
@@ -333,13 +339,13 @@ Extra commands
   If an idb is enable then IDA's view is synced with the resulting address. Address is not rebased
   and there is no idb switching.
   Especially useful for dynamically allocated/generated code.
-  
+
 * **!modmap <base> <size> <name>**
 
   A synthetic ("faked") module (defined using its base address and size) is added to the debugger internal list.
   From msdn: "If all the modules are reloaded - for example, by calling Reload with the Module parameter set to an empty string - all synthetic modules will be discarded."
   It can be used to more easily debug dynamically allocated/generated code.
-  
+
 * **!modunmap <base>**
 
   Remove a previously mapped synthetic module at base address.
@@ -351,9 +357,9 @@ Extra commands
   but only with local debuggee (not in remote kernel debugging).
 
 * **!bpcmds <||save|load|>**
-  
-  **bpcmds** wrapper, save and reload **.bpcmds** (breakpoints commands list) output to current idb. 
-  Display (but not execute) saved data if called with no argument. 
+
+  **bpcmds** wrapper, save and reload **.bpcmds** (breakpoints commands list) output to current idb.
+  Display (but not execute) saved data if called with no argument.
   Persistent storage is achieved using IDA's netnode feature.
 
 * **!ks**
@@ -366,7 +372,7 @@ Extra commands
 
 
 Address optional argument
--------------------------
++++++++++++++++++++++++++
 
 !cmt, !rcmt and !fcmt commands support an optional address option: -a or --address.
 Address should be passed as an hexadecimal value. Command parsing is based on python's
@@ -379,10 +385,10 @@ The address has to be a valid instruction's address.
 
 
 
-IDA bindings over Windbg commands:
-----------------------------------
+IDA bindings over WinDbg commands:
+++++++++++++++++++++++++++++++++++
 
-``Syncplugin.py`` also registers Windbg command wrapper hotkeys.
+``Syncplugin.py`` also registers WinDbg command wrapper hotkeys.
 
 * F2  - Set breakpoint at cursor address
 * F3  - Set one-shot breakpoint at cursor address
@@ -399,7 +405,10 @@ These commands are only available when the current idb is active. When possible 
 GNU gdb (GDB)
 -------------
 
-GDB support is experimental, however:
+GDB has also been heavily tested. We only describe a subset of the capabilities. Refer to WinDbg commands for a more complete description of what is supported.
+
+Use it
+++++++
 
 0. Load extension (see auto-load-scripts)::
 
@@ -433,6 +442,106 @@ GDB support is experimental, however:
      > fcmt [-a address] <string>
      > cmd <string>
      > bc <on|off|>
+     > rln <address>
+     > bbt <symbol>
+     > patch <addr> <count> <size>
+     > bx /i <symbol>
+     > cc
+     > translate <base> <addr> <mod>
+
+* **rln**
+
+  Get symbol from the idb for the given address
+
+* **bbt**
+
+  Beautiful backtrace. Similar to **bt** but requests symbols from IDA:::
+
+    (gdb) bt
+    #0  0x0000000000a91a73 in ?? ()
+    #1  0x0000000000a6d994 in ?? ()
+    #2  0x0000000000a89125 in ?? ()
+    #3  0x0000000000a8a574 in ?? ()
+    #4  0x000000000044f83b in ?? ()
+    #5  0x0000000000000000 in ?? ()
+    (gdb) bbt
+    #0 0x0000000000a91a73 in IKE_GetAssembledPkt ()
+    #1 0x0000000000a6d994 in catcher ()
+    #2 0x0000000000a89125 in IKEProcessMsg ()
+    #3 0x0000000000a8a574 in IkeDaemon ()
+    #4 0x000000000044f83b in sub_44F7D0 ()
+    #5 0x0000000000000000 in  ()
+
+* **patch**
+
+  Patch bytes in IDA based on live context
+
+* **bx**
+
+  Beautiful display. Similar to **x** but using a symbol. The symbol will be resolved by IDA.
+
+* **cc**
+
+  Continue to cursor in IDA. This is an alternative to using F3 to set a one-shot breakpoint and
+  F5 to continue. This is useful if you prefer to do it from gdb:::
+
+    (gdb) b* 0xA91A73
+    Breakpoint 1 at 0xa91a73
+    (gdb) c
+    Continuing.
+
+    Breakpoint 1, 0x0000000000a91a73 in ?? ()
+    (gdb) cc
+    [sync] current cursor: 0xa91a7f
+    [sync] reached successfully
+    (gdb)
+
+
+Override PID, memory mappings
++++++++++++++++++++++++++++++
+
+In some scenario such as debugging embedded devices over serial, gdb is not aware of the PID and cannot access
+`/proc/<pid>/maps`. In this case, we import a different script than sync.py in gdb. This script is quite simple and imports sync.py. The only difference is we create a context that is passed to `Sync()` when instanciating the object.
+It allows overriding some fields such as the pid or mappings but others could be added if required.
+
+  custom_sync.py:::
+
+    from sync import *
+
+    if __name__ == "__main__":
+
+        locations = [os.path.join(os.path.realpath(os.path.dirname(__file__)), ".sync"),
+                     os.path.join(os.environ['HOME'], ".sync")]
+
+        for confpath in locations:
+            if os.path.exists(confpath):
+                config = configparser.SafeConfigParser({'host': HOST, 'port': PORT})
+                config.read(confpath)
+                HOST = config.get("INTERFACE", 'host')
+                PORT = config.getint("INTERFACE", 'port')
+                print("[sync] configuration file loaded %s:%s" % (HOST, PORT))
+                break
+
+        ctx = {
+            "pid": 200,
+            "mappings": [ [0x400000, 0x7A81158, 0x7681158, "asav941-200.qcow2|lina"] ]
+        }
+
+        sync = Sync(HOST, ctx=ctx)
+
+        Syncoff(sync)
+        Cmt(sync)
+        Rcmt(sync)
+        Fcmt(sync)
+        Bc(sync)
+        Translate(sync)
+        Cmd(sync)
+        Rln(sync)
+        Bbt(sync)
+        Bx(sync)
+        Cc(sync)
+        Patch(sync)
+        Help()
 
 
 LLDB
@@ -519,21 +628,21 @@ KNOWN BUGS/LIMITATIONS
 
 - Tested with Python 2.7, IDA 6.4 to 6.9 (Windows, Linux and Mac OS X), GNU gdb (GDB) 7.4.1 (Debian), lldb 310.2.37.
 - **THERE IS NO AUTHENTICATION/ENCRYPTION** or whatsoever between the parties; you're on your own.
-- Self modifying code is out of scope. 
-  
+- Self modifying code is out of scope.
+
 With GDB:
 
 - it seems that stop event is not called when using 'return' command.
 - multi-threading debugging have issues with signals.
- 
-With Windbg:
+
+With WinDbg:
 
 - IDA's client plugin gets notified even though encountered breakpoint
   uses a command string that makes it continue ('g'). This can cause major slow-down
   if there are too much of these events. A limited fix has been implemented, the
   best solution is still to sync off temporarily.
-- Possible race condition 
- 
+- Possible race condition
+
 With IDA:
 
 - Graph window redrawing is quite slow for big graphs.

--- a/ext_ida/broker.py
+++ b/ext_ida/broker.py
@@ -17,10 +17,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
+# Note that broker.py is executed by IDA Pro so it is not possible to see
+# any output using print() or similar
 
 import os
 import sys
@@ -265,9 +267,10 @@ if __name__ == "__main__":
         if loc in os.environ:
             confpath = os.path.join(os.path.realpath(os.environ[loc]), '.sync')
             if os.path.exists(confpath):
-                config = ConfigParser.SafeConfigParser({'port': PORT})
+                config = ConfigParser.SafeConfigParser({'port': PORT, 'host': HOST})
                 config.read(confpath)
                 PORT = config.getint("INTERFACE", 'port')
+                HOST = config.get("INTERFACE", 'host')
                 break
 
     server = BrokerSrv(args.idb[0])

--- a/ext_ida/dispatcher.py
+++ b/ext_ida/dispatcher.py
@@ -83,7 +83,7 @@ class DispatcherSrv():
         self.current_module = None
 
         self.sync_mode_auto = True
-        self.pat = re.compile('dbg disconnected')
+        self.disconn_pat = re.compile('dbg disconnected')
         self.req_handlers = {
             'new_client': self.req_new_client,
             'new_dbg': self.req_new_dbg,
@@ -181,7 +181,7 @@ class DispatcherSrv():
             # this is a normal [sync] request from debugger, forward it
             self.forward(req)
             # receive 'dbg disconnected', socket can be closed
-            if re.search(self.pat, req):
+            if re.search(self.disconn_pat, req):
                 self.close(s)
             return
 


### PR DESCRIPTION
Lots of improvements:
- new gdb commands such as rln, bbt, bx, cc and patch
- better synchronisation
- support external pid, mapping
These improvements are detailed below.

The new gdb commands are:
- rln: ask IDA Pro to convert an address into a symbol
- bbt: beautiful backtrace by executing "bt" and retrieving
       symbols from IDA Pro for each element of the bt
- bx: similar to "x" but supports a symbol resolved by IDA
- cc: continue to current cursor in IDA Pro (set a breakpoint,
      continue and remove the bp)
- patch: patch memory in IDA based on live information in gdb

The communication with the broker as been improved.
Sometimes the whole JSON is not received at once.
We cache it until we receive the ending "}".

Added support for importing a context to the gdb plugin.
In some scenario such as debugging embedded devices over
serial, gdb is not aware of the PID and cannot access
/proc/<pid>/maps. In this case, we import a different file
than sync.py in gdb which is quite simple and import sync.py.
The only difference is we create a context that is passed
to Sync() when instanciating the object. It allows overriding
some fields such as the pid or mappings but other could be
added if required.

```
from sync import *

if __name__ == "__main__":

    ctx = { "pid": 200,
            "mappings": [0x08048000, 0x0B74ae20, 0x03702e20, "asa924-k8.bin|lina"]
    }
    //...
    sync = Sync(HOST, ctx=ctx)
    //...
```

A few other small fixes such as:
- better parsing of config file at several places
- more logging in IDA output window
- fixed some polling error that appeared in gdb when syncing failed