### PR TITLE
Add new configuration option use_tmp_logging_file to gdb extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,18 @@ Here we simply tell to the dispatcher to match the name `ntkrnlmp.exe` (real
 name) instead of `ntoskrnl_vuln.exe` (IDB name).
 
 
+## gdb with Qt Creator debugging frontend
+
+The Qt Creator debugging frontend changes the way gdb command output is logged. Since
+this would interfere with the synchronization an option exists to use the raw gdb output
+for synchronization instead of a temporary file. In the .sync configuration file use
+
+```
+[GENERAL]
+use_tmp_logging_file=false
+```
+
+if you wish to use the Qt debugging frontend for the target.
 
 ## Embedded devices and missing ``/proc/<pid>/maps``
 

--- a/ext_gdb/sync.py
+++ b/ext_gdb/sync.py
@@ -43,7 +43,7 @@ except ImportError:
 
 HOST = "localhost"
 PORT = 9100
-
+USE_TMP_LOGGING_FILE = True
 TIMER_PERIOD = 0.2
 PYTHON_MAJOR = sys.version_info[0]
 
@@ -85,6 +85,8 @@ def show_last_exception(cmd):
 # function gdb_execute courtesy of StalkR
 # Wrapper when gdb.execute(cmd, to_string=True) does not work
 def gdb_execute(cmd):
+    if not USE_TMP_LOGGING_FILE:
+        return gdb.execute(cmd, to_string=True)
     f = tempfile.NamedTemporaryFile()
     gdb.execute("set logging file %s" % f.name)
     gdb.execute("set logging redirect on")
@@ -927,9 +929,12 @@ if __name__ == "__main__":
 
     for confpath in [os.path.join(p, '.sync') for p in locations]:
         if os.path.exists(confpath):
-            config = configparser.SafeConfigParser({'host': HOST, 'port': PORT, 'context': ''})
+            config = configparser.SafeConfigParser({'host': HOST, 'port': PORT, 'context': '', 'use_tmp_logging_file': USE_TMP_LOGGING_FILE})
             config.read(confpath)
             print("[sync] configuration file loaded from: %s" % confpath)
+            if config.has_section('GENERAL'):
+                USE_TMP_LOGGING_FILE = config.getboolean('GENERAL', 'use_tmp_logging_file')
+                print("       general: use_tmp_logging_file is %s" % USE_TMP_LOGGING_FILE)
 
             if config.has_section('INTERFACE'):
                 HOST = config.get('INTERFACE', 'host')


### PR DESCRIPTION
The reason this was added was that the use of a temporary file to
capture the gdb output does not work in my case - namely when using
the Qt Creator debugging frontend. The output was messed up and
the proc map could not be parsed correctly.

With the new option the output to temporary files can be deactivated
which worked in my case.