### PR TITLE
Ghidra tries to resolve incorrect address

### DIFF
--- a/ext_gdb/sync.py
+++ b/ext_gdb/sync.py
@@ -732,7 +732,7 @@ class Bbt(WrappedCommand):
 
                 # XXX - we don't support a rebase yet
                 self.sync.tunnel.send("[sync]{\"type\":\"rln\",\"raddr\":%d,\"rbase\":%d,\"base\":%d,\"offset\":%d}\n" %
-                                      (raddr, 0x0, self.sync.base, self.sync.offset))
+                                      (raddr, self.sync.base, self.sync.base, self.sync.offset))
 
                 # Let time for the IDB client to reply if it exists
                 time.sleep(0.150)


### PR DESCRIPTION
before resolving the symbol, the ghidra module calls `imageBaseLocal.addNoWrap(raddr - rbase)` to get the final address to resolve the symbol.
Because `raddr` is not an offset but the final address (`rbase` is zero so no base is substracted), the base is added to an already final address making it an undesired address.

This fix is only taking into account the ghidra module because I am not sure if the other modules have the same problem.