### PR TITLE
Fix Python 2.7 missing DEVNULL

### DIFF
--- a/ext_ida/retsync/broker.py
+++ b/ext_ida/retsync/broker.py
@@ -47,7 +47,6 @@ except ImportError:
 try:
     from subprocess import DEVNULL
 except ImportError:
-    import os
     DEVNULL = open(os.devnull, 'wb')
 
 import rsconfig

--- a/ext_ida/retsync/broker.py
+++ b/ext_ida/retsync/broker.py
@@ -43,6 +43,13 @@ except ImportError:
     print("[-] failed to import json\n%s" % repr(sys.exc_info()))
     sys.exit(0)
 
+# python 2.7 compat
+try:
+    from subprocess import DEVNULL
+except ImportError:
+    import os
+    DEVNULL = open(os.devnull, 'wb')
+
 import rsconfig
 from rsconfig import rs_encode, rs_decode
 
@@ -109,8 +116,8 @@ class BrokerSrv():
         args = [arg.replace('\"', '') for arg in list(tokenizer)]
         try:
             proc = subprocess.Popen(args, shell=False,
-                                    stdout=subprocess.DEVNULL,
-                                    stderr=subprocess.DEVNULL)
+                                    stdout=DEVNULL,
+                                    stderr=DEVNULL)
             pid = proc.pid
         except (OSError, ValueError):
             pid = None


### PR DESCRIPTION
Commit 0f49a7d7f50c32005506c63f95019699f5617feb added a fix for stdout with POpen. Python 2.7 (IDA versions <=7.2) does not have `subprocess.DEVNULL` so a workaround is used. Without this workaround, the broker will not launch without an exception.

Thanks :)