### PR TITLE
[ext_ghidra] correctly handle null Address when resolving symbols

### DIFF
--- a/ext_ghidra/src/main/java/retsync/RetSyncPlugin.java
+++ b/ext_ghidra/src/main/java/retsync/RetSyncPlugin.java
@@ -507,6 +507,12 @@ public class RetSyncPlugin extends ProgramPlugin {
 
     String getSymAt(Address symAddr) {
         String symName = null;
+
+        if (symAddr == null) {
+            cs.println(String.format("[x] failed to get symbol at null address"));
+            return null;
+        }
+
         SymbolTable symTable = program.getSymbolTable();
 
         // look for 'first-hand' symbol (function name, label, etc.)


### PR DESCRIPTION
If the debugger sends an rln command with an address that does not
rebase correctly (example: an address that wraps), a null Address will
be passed to getSymAt. This throws a NullPointerException that requires
the CodeBrowser tool to be closed and reopened before the plugin
functions again.