### PR TITLE
Handling QT6 compatability with newer Binja UI

### DIFF
--- a/ext_bn/retsync/__init__.py
+++ b/ext_bn/retsync/__init__.py
@@ -26,12 +26,18 @@ SOFTWARE.
 
 from collections import namedtuple
 
-from PySide2.QtCore import Qt
-from PySide2.QtGui import QKeySequence
-from binaryninjaui import UIAction, UIActionHandler
+import binaryninjaui
+if 'qt_major_version' in binaryninjaui.__dict__ and binaryninjaui.qt_major_version == 6:
+    from PySide6.QtCore import Qt
+    from PySide6.QtGui import QKeySequence
+
+else:
+    from PySide2.QtCore import Qt
+    from PySide2.QtGui import QKeySequence
 
 from .sync import SyncPlugin
 from .retsync.rsconfig import rs_log
+from binaryninjaui import UIAction, UIActionHandler
 
 
 def add_commands(plugin):

--- a/ext_bn/retsync/__init__.py
+++ b/ext_bn/retsync/__init__.py
@@ -30,7 +30,6 @@ import binaryninjaui
 if 'qt_major_version' in binaryninjaui.__dict__ and binaryninjaui.qt_major_version == 6:
     from PySide6.QtCore import Qt
     from PySide6.QtGui import QKeySequence
-
 else:
     from PySide2.QtCore import Qt
     from PySide2.QtGui import QKeySequence

--- a/ext_bn/retsync/__init__.py
+++ b/ext_bn/retsync/__init__.py
@@ -35,9 +35,10 @@ else:
     from PySide2.QtCore import Qt
     from PySide2.QtGui import QKeySequence
 
+from binaryninjaui import UIAction, UIActionHandler
+
 from .sync import SyncPlugin
 from .retsync.rsconfig import rs_log
-from binaryninjaui import UIAction, UIActionHandler
 
 
 def add_commands(plugin):

--- a/ext_bn/retsync/retsync/rswidget.py
+++ b/ext_bn/retsync/retsync/rswidget.py
@@ -23,14 +23,22 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
+import binaryninjaui
+if 'qt_major_version' in binaryninjaui.__dict__ and binaryninjaui.qt_major_version == 6:
+    from PySide6 import QtCore
+    from PySide6.QtCore import Qt
+    from PySide6.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QLabel, QWidget
+    from PySide6.QtGui import QKeySequence
+
+else:
+    from PySide2 import QtCore
+    from PySide2.QtCore import Qt
+    from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QLabel, QWidget
+    from PySide2.QtGui import QKeySequence
 
 from binaryninjaui import UIAction, UIActionHandler
 from binaryninjaui import DockHandler, DockContextHandler
 
-from PySide2 import QtCore
-from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QLabel, QWidget
-from PySide2.QtGui import QKeySequence
 
 from .rsconfig import rs_log
 

--- a/ext_bn/retsync/retsync/rswidget.py
+++ b/ext_bn/retsync/retsync/rswidget.py
@@ -29,7 +29,6 @@ if 'qt_major_version' in binaryninjaui.__dict__ and binaryninjaui.qt_major_versi
     from PySide6.QtCore import Qt
     from PySide6.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QLabel, QWidget
     from PySide6.QtGui import QKeySequence
-
 else:
     from PySide2 import QtCore
     from PySide2.QtCore import Qt

--- a/ext_bn/retsync/sync.py
+++ b/ext_bn/retsync/sync.py
@@ -23,6 +23,13 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
+import binaryninjaui
+if 'qt_major_version' in binaryninjaui.__dict__ and binaryninjaui.qt_major_version == 6:
+    from PySide6 import QtCore
+    from PySide6.QtCore import Qt
+else:
+    from PySide2 import QtCore
+    from PySide2.QtCore import Qt
 
 from binaryninjaui import DockHandler
 from binaryninjaui import UIAction, UIActionHandler, UIContext, UIContextNotification
@@ -30,8 +37,6 @@ from binaryninjaui import ViewFrame
 
 from binaryninja.plugin import BackgroundTaskThread, PluginCommand
 
-from PySide2 import QtCore
-from PySide2.QtCore import Qt
 
 from collections import OrderedDict
 import socket


### PR DESCRIPTION
Binary Ninja have moved to using QT6 on development branch. It is required to handle different QT version depending on Binary Ninja builds.