### PR TITLE
[ext_bn] bc logic on binaryninja was reversed

### DIFF
--- a/ext_bn/retsync/sync.py
+++ b/ext_bn/retsync/sync.py
@@ -636,7 +636,7 @@ class SyncPlugin(UIContextNotification):
             if not self.binary_view.navigate(view, goto_addr):
                 rs_log(f"goto {hex(goto_addr)} error")
 
-            if not self.cb_trace_enabled:
+            if self.cb_trace_enabled:
                 self.color_callback(goto_addr)
         else:
             rs_log('goto: no view available')


### PR DESCRIPTION
`bc on` command will turn highlight off while `bc off` will turn the highlight on. Due to this, highlight by default was always on.