### PR TITLE
Make Ghidra address translation optional using a checkbox

### DIFF
--- a/ext_ghidra/src/main/java/retsync/RetSyncComponent.java
+++ b/ext_ghidra/src/main/java/retsync/RetSyncComponent.java
@@ -31,6 +31,7 @@ import javax.swing.Icon;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JCheckBox;
 import javax.swing.SwingConstants;
 
 import org.apache.commons.io.FilenameUtils;
@@ -59,6 +60,7 @@ public class RetSyncComponent extends ComponentProvider {
     private JLabel statusArea;
     private JLabel clientArea;
     private JLabel programArea;
+    private JCheckBox translateAddresses;
 
     private DockingAction action_enable;
     private DockingAction action_disable;
@@ -117,6 +119,9 @@ public class RetSyncComponent extends ComponentProvider {
         Icon CODE_ICON = ResourceManager.loadImage("images/viewedCode.gif");
         programArea = new JLabel(CODE_ICON, SwingConstants.LEFT);
         panel.add(programArea, gbc);
+
+        translateAddresses = new JCheckBox("Translate addresses", true);
+        panel.add(translateAddresses, gbc);
     }
 
     private NavigatableContextAction codeViewerActionFactory(String name, String cmd, KeyBindingData keyBinding) {
@@ -335,14 +340,21 @@ public class RetSyncComponent extends ComponentProvider {
         switch (status) {
         case Status.IDLE:
             statusArea.setForeground(Color.BLACK);
+            translateAddresses.setEnabled(true);
             break;
         case Status.ENABLED:
             statusArea.setForeground(Color.BLUE);
+            translateAddresses.setEnabled(true);
             break;
         case Status.RUNNING:
+            translateAddresses.setEnabled(false);
             statusArea.setForeground(COLOR_CONNECTED);
             break;
         }
+    }
+
+    public boolean getTranslate() {
+        return translateAddresses.isSelected();
     }
 
     @Override

--- a/ext_ghidra/src/main/java/retsync/RetSyncPlugin.java
+++ b/ext_ghidra/src/main/java/retsync/RetSyncPlugin.java
@@ -353,7 +353,11 @@ public class RetSyncPlugin extends ProgramPlugin {
     // current program image base and update remote base address
     Address rebase(long base, long offset) {
         imageBaseRemote = imageBaseLocal.getNewAddress(base);
-        return rebaseLocal(imageBaseLocal.getNewAddress(offset));
+        if(uiComponent.getTranslate()) {
+            return rebaseLocal(imageBaseLocal.getNewAddress(offset));
+        } else {
+            return imageBaseLocal.getNewAddress(offset);
+        }
     }
 
     // rebase remote address with respect to
@@ -389,6 +393,9 @@ public class RetSyncPlugin extends ProgramPlugin {
     // rebase local address with respect to
     // remote program image base
     Address rebaseRemote(Address loc) {
+        if (!uiComponent.getTranslate()) {
+            return loc;
+        }
         Address dest;
 
         if (program == null)


### PR DESCRIPTION
This pull request adds a checkbox to the Ghidra panel in the plugin, for making address translation optional. This is convenient when using ret-sync with a GDB stub on a device without an enabled MMU. 

In this case, the device sends raw hardware addresses, which the ret-sync plugin then tries to translate using the base address of the loaded binary in Ghidra, which (among other stuff) makes the program counter jump to the wrong places and fails to set the correct breakpoints.

This pull request doesn't change the default behavior, but does make it optional to do so.