### PR TITLE
Fix Linux python path

### DIFF
--- a/ext_ida/retsync/rsconfig.py
+++ b/ext_ida/retsync/rsconfig.py
@@ -195,7 +195,7 @@ for py_rel in PY3_RELEASES:
 
 
 # default paths Linux/Mac OS X platforms
-PY_LINUX_DEFAULTS = ("/usr/bin")
+PY_LINUX_DEFAULTS = ("/usr/bin",)
 
 
 # retsync plugin needs a Python interpreter to run broker and dispatcher


### PR DESCRIPTION
The origin code at line 198 was

```
PY_LINUX_DEFAULTS = ("/usr/bin")
```

Cause the code at 237 to iterate each char of it, should be corrected as a tuple:

```
PY_LINUX_DEFAULTS = ("/usr/bin",)
```