### PR TITLE
fixed a bug which causes dispatcher crash

### DIFF
--- a/ext_ida/retsync/dispatcher.py
+++ b/ext_ida/retsync/dispatcher.py
@@ -414,7 +414,7 @@ class DispatcherSrv():
     def req_module(self, s, hash):
         modpath = hash['path']
         self.current_module = modname = altpath.basename(modpath)
-        matching = [idbc for idbc in self.idb_clients if (idbc.name.lower() == modname.lower())]
+        matching = [idbc for idbc in self.idb_clients if (idbc.name is not None and idbc.name.lower() == modname.lower())]
 
         if not self.sync_mode_auto:
             self.broadcast('sync_mode_auto off')


### PR DESCRIPTION
with Python 3.10 and trying to jumpto some address the dispatcher processes crashed.

When a new process connects to the dispatcher port but it does not intend to be a full functional client, the dispatcher server will assign a temporary `client` structure to it with name=None, however, the checks in server loop crashed as it tries to lowercase the None object.