### PR TITLE
Change addBraceHighlight -> addPrimaryHighlightToTokensForBrace for Ghidra 11.2

### DIFF
--- a/ext_ghidra/src/main/java/retsync/LocalColorizerService.java
+++ b/ext_ghidra/src/main/java/retsync/LocalColorizerService.java
@@ -299,7 +299,7 @@ public class LocalColorizerService {
             addPrimaryHighlight(token, defaultHighlightColor);
             if (token instanceof ClangSyntaxToken) {
                 addPrimaryHighlightToTokensForParenthesis((ClangSyntaxToken) token, defaultParenColor);
-                addBraceHighlight((ClangSyntaxToken) token, defaultParenColor);
+                addPrimaryHighlightToTokensForBrace((ClangSyntaxToken) token, defaultParenColor);
             }
         }
     }


### PR DESCRIPTION
It looks like `addBraceHighlight` was renamed to `addPrimaryHighlightToTokensForBrace` in Ghidra 11.2:

https://github.com/NationalSecurityAgency/ghidra/commit/9f8b03a90f344ef10cdbd5c9a0036b2fb88fdce2

This makes things compile again.