### PR TITLE
Change REGDUMP to REGDUMP_AVX512 in core.cpp

### DIFF
--- a/ext_x64dbg/x64dbg_sync/core.cpp
+++ b/ext_x64dbg/x64dbg_sync/core.cpp
@@ -40,7 +40,7 @@ static CRITICAL_SECTION g_CritSectPollRelease;
 // Debuggee's state;
 ULONG_PTR g_Offset = NULL;
 ULONG_PTR g_Base = NULL;
-REGDUMP regs;
+REGDUMP_AVX512 regs;
 
 // Synchronisation mode
 static BOOL g_SyncAuto = true;


### PR DESCRIPTION
Fixes a compile error with the latest x64dbg sdk