### PR TITLE
Fix rln address parsing in GDB plugin

### DIFF
--- a/ext_gdb/sync.py
+++ b/ext_gdb/sync.py
@@ -804,7 +804,7 @@ class Rln(WrappedCommand):
             value = gdb.parse_and_eval(arg)
             if (str(value)) == 'void':
                 raise ValueError
-            raddr = int(str(value), 16)
+            raddr = int(value)
         except ValueError as e:
             rs_log("rln: failed to evaluate expression \"%s\"" % arg)
             rs_log("     hint: be careful of register name case ($RIP ->$rip, cf. info registers)")


### PR DESCRIPTION
This PR fixes incorrect address parsing in the GDB `rln` command.

Previously, `int(str(value), 16)` depended on `gdb.Value` string formatting,
which may be displayed in decimal (e.g. under pwndbg), causing hex addresses
to be misinterpreted.

This patch uses `int(value)` to retrieve the numeric value reliably.
This is a minimal change and does not affect existing behavior.

Example:
- `rln 0x111d` was resolved as `0x4381`
- Now it resolves correctly as `0x111d`

Tested with GDB + pwndbg on PIE binaries.
